### PR TITLE
docs: simplify package names across the documentation

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -49,7 +49,6 @@ export default defineConfig({
     selectors: [
       {
         items: packages.map((entry) => ({
-          description: entry.description,
           label: entry.slug,
           path: `/${entry.slug}`,
           tag: `v${entry.version}`,

--- a/apps/docs/content/cache/index.mdx
+++ b/apps/docs/content/cache/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/cache"
+title: cache
 description: Zero-dependency in-memory key-value cache with pluggable eviction policies, capacity limits, and optional TTL.
 sidebar:
   label: Overview
@@ -7,13 +7,13 @@ type: package
 package: "@zap-studio/cache"
 ---
 
-`@zap-studio/cache` is a zero-dependency in-memory key-value cache with pluggable eviction policies, capacity limits, and optional TTL.
+`cache` is a zero-dependency in-memory key-value cache with pluggable eviction policies, capacity limits, and optional TTL.
 
 ## Motivation
 
 A hand-rolled `Map`-based cache without a capacity limit is a memory leak waiting to happen — nothing ever gets removed. Reaching for a library instead usually means choosing between something that bakes in one eviction algorithm (LRU only, no LFU or FIFO) or a full-featured cache far bigger than a lean cache needs (cost-based sizing, stale-while-revalidate).
 
-`@zap-studio/cache` keeps the core cache policy-agnostic: `createCache(capacity, options?)` handles storage, capacity, and TTL, while the eviction algorithm is a small object you pass in. Five are built in — `lru()`, `lfu()`, `mru()`, `mfu()`, and `fifo()` — and the `EvictionPolicy` interface is public, so you can write your own without forking the package.
+`cache` keeps the core cache policy-agnostic: `createCache(capacity, options?)` handles storage, capacity, and TTL, while the eviction algorithm is a small object you pass in. Five are built in — `lru()`, `lfu()`, `mru()`, `mfu()`, and `fifo()` — and the `EvictionPolicy` interface is public, so you can write your own without forking the package.
 
 ## Features
 

--- a/apps/docs/content/cache/meta.ts
+++ b/apps/docs/content/cache/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/cache",
+  title: "cache",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/env/errors.mdx
+++ b/apps/docs/content/env/errors.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/env"
 ---
 
-`@zap-studio/env` throws three structured errors, each covering a different failure: a bad setup, a failed validation, and an out-of-bounds read. All three extend `Error`.
+`env` throws three structured errors, each covering a different failure: a bad setup, a failed validation, and an out-of-bounds read. All three extend `Error`.
 
 ## `EnvironmentError`
 

--- a/apps/docs/content/env/index.mdx
+++ b/apps/docs/content/env/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/env"
+title: env
 description: A runtime and framework-agnostic environment variable validator, built on Standard Schema.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/env"
 ---
 
-`@zap-studio/env` checks an env object you already have (`process.env`, `import.meta.env`, dotenv output, or anything else) against a [Standard Schema](https://standardschema.dev/schema)-based `shared`/`server`/`client` shape. It does not read or parse files itself.
+`env` checks an env object you already have (`process.env`, `import.meta.env`, dotenv output, or anything else) against a [Standard Schema](https://standardschema.dev/schema)-based `shared`/`server`/`client` shape. It does not read or parse files itself.
 
 It works the same way in Node, Deno, Bun, Cloudflare Workers, edge runtimes, and the browser, with any bundler or framework. It does not scan env vars itself. This is why it does not break the static `process.env`/`import.meta.env` replacement that bundlers use. But that replacement only works on a literal `process.env.X` line in your own code. For `client` vars, use [`runtimeEnvStrict`](/env/advanced-options#runtimeenvstrict) and write each key on its own line. Do not pass the whole object instead.
 
@@ -15,9 +15,9 @@ It works the same way in Node, Deno, Bun, Cloudflare Workers, edge runtimes, and
 
 It uses the same `server`/`client`/`shared` split as [t3-env](https://env.t3.gg), the package most people use for this job today. A server secret cannot leak into a client bundle by accident. But t3-env still has real problems: its `extends` does a flat merge with no conflict check, so a key can silently get dropped or overwritten. Its presets do not cover Cloudflare Workers or Deno Deploy. And framework support needs its own packages, like `env-nextjs` and `env-nuxt`, tying the core package to one framework.
 
-[envin](https://envin.turbostarter.dev) already fixes some of this. It adds a CLI, better preset and `extends` support, and a live env preview. `@zap-studio/env` goes further in two ways: its `extends` merges schemas at the key level and throws right away if two sources use the same key with two different schemas, and it ships presets for Cloudflare Workers and Deno Deploy, which neither t3-env nor envin do.
+[envin](https://envin.turbostarter.dev) already fixes some of this. It adds a CLI, better preset and `extends` support, and a live env preview. `env` goes further in two ways: its `extends` merges schemas at the key level and throws right away if two sources use the same key with two different schemas, and it ships presets for Cloudflare Workers and Deno Deploy, which neither t3-env nor envin do.
 
-Instead of a live preview through a dev server, `@zap-studio/env` takes a simpler, static approach: [`generateEnvironmentExample`](/env/generate-env-example) builds a `.env.example` file straight from your schema. No dev server needed, so it's safe to run in CI and commit.
+Instead of a live preview through a dev server, `env` takes a simpler, static approach: [`generateEnvironmentExample`](/env/generate-env-example) builds a `.env.example` file straight from your schema. No dev server needed, so it's safe to run in CI and commit.
 
 ## Features
 

--- a/apps/docs/content/env/meta.ts
+++ b/apps/docs/content/env/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/env",
+  title: "env",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/env/opentelemetry.mdx
+++ b/apps/docs/content/env/opentelemetry.mdx
@@ -57,7 +57,7 @@ When [`skipValidation`](/env/advanced-options#skipvalidation) is `true`, `create
 
 ## Log Correlation
 
-Pair this with [`@zap-studio/logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so anything you log around startup lines up with the `env.validate` span.
+Pair this with [`logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so anything you log around startup lines up with the `env.validate` span.
 
 ## See Also
 

--- a/apps/docs/content/fetch/errors.mdx
+++ b/apps/docs/content/fetch/errors.mdx
@@ -5,12 +5,12 @@ type: package
 package: "@zap-studio/fetch"
 ---
 
-`@zap-studio/fetch` throws `FetchError` for HTTP failures and `ValidationError` for schema failures. Platform and schema errors can still propagate from native `fetch`, body parsing, request construction, or the validator itself.
+`fetch` throws `FetchError` for HTTP failures and `ValidationError` for schema failures. Platform and schema errors can still propagate from native `fetch`, body parsing, request construction, or the validator itself.
 
-| Error             | Import path              | Thrown when                                                                                        |
-| ----------------- | ------------------------ | -------------------------------------------------------------------------------------------------- |
-| `FetchError`      | `@zap-studio/fetch`      | The response is not ok and `throwOnFetchError` is `true` (default).                                |
-| `ValidationError` | `@zap-studio/validation` | A schema is provided, validation returns issues, and `throwOnValidationError` is `true` (default). |
+| Error             | Import path  | Thrown when                                                                                        |
+| ----------------- | ------------ | -------------------------------------------------------------------------------------------------- |
+| `FetchError`      | `fetch`      | The response is not ok and `throwOnFetchError` is `true` (default).                                |
+| `ValidationError` | `validation` | A schema is provided, validation returns issues, and `throwOnValidationError` is `true` (default). |
 
 ```ts
 import { FetchError } from "@zap-studio/fetch";

--- a/apps/docs/content/fetch/index.mdx
+++ b/apps/docs/content/fetch/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/fetch"
+title: fetch
 description: A type-safe fetch wrapper that validates JSON responses at runtime with any Standard Schema validator.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/fetch"
 ---
 
-`@zap-studio/fetch` is a small fetch wrapper with [**Standard Schema**](https://standardschema.dev/schema) response validation.
+`fetch` is a small fetch wrapper with [**Standard Schema**](https://standardschema.dev/schema) response validation.
 
 ## Motivation
 
@@ -15,7 +15,7 @@ Raw `fetch` does not throw on HTTP errors like 404 or 500 — you must check `re
 
 So most projects add the same pattern at every call site: check the status, parse the JSON, then validate it with `schema.parse(await res.json())`. It is easy to forget one of these steps somewhere, and that is how bad data or a network error goes unnoticed until it breaks something downstream.
 
-`@zap-studio/fetch` makes this pattern the default, not something you write by hand. `api.get(url, UserSchema)` checks the response, validates the body, and throws a clear, typed error — `FetchError` for a bad HTTP status, `ValidationError` for a bad shape — so you always know what went wrong and where.
+`fetch` makes this pattern the default, not something you write by hand. `api.get(url, UserSchema)` checks the response, validates the body, and throws a clear, typed error — `FetchError` for a bad HTTP status, `ValidationError` for a bad shape — so you always know what went wrong and where.
 
 It uses [Standard Schema](https://standardschema.dev/schema), so you are not locked into one validation library: start with Zod, move to Valibot later, and the call sites do not change. And because it only wraps the global `fetch` function, it is not a Node-only HTTP client — it runs the same way on Bun, Deno, Cloudflare Workers, and in the browser.
 
@@ -28,7 +28,7 @@ It uses [Standard Schema](https://standardschema.dev/schema), so you are not loc
 - **JSON convenience** through the `json` option, which serializes the request body and sets `Content-Type`.
 - **Structured errors** with `FetchError` for HTTP failures and `ValidationError` for schema failures.
 - **Validator-agnostic** — works with any library that implements Standard Schema.
-- **[Optional logging](/fetch/logging)** through `createFetch({ logger })` from [`@zap-studio/logger`](/logger) — omit it and there's zero logging overhead.
+- **[Optional logging](/fetch/logging)** through `createFetch({ logger })` from [`logger`](/logger) — omit it and there's zero logging overhead.
 - **[Native OpenTelemetry](/fetch/opentelemetry)** — a `CLIENT` span per request with trace context injected into outgoing headers, no-op until an SDK is registered.
 - **Tree-shakeable** — every export is a standalone function with no shared internal state; unused exports are dropped by any modern bundler.
 

--- a/apps/docs/content/fetch/logging.mdx
+++ b/apps/docs/content/fetch/logging.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/fetch"
 ---
 
-`createFetch(...)` accepts an optional `logger?: Logger` option from [`@zap-studio/logger`](/logger). Pass one to observe request internals; omit it and nothing is logged — zero overhead.
+`createFetch(...)` accepts an optional `logger?: Logger` option from [`logger`](/logger). Pass one to observe request internals; omit it and nothing is logged — zero overhead.
 
 ```ts
 import { ConsoleLogger } from "@zap-studio/logger";
@@ -45,4 +45,4 @@ const logger: Logger = {
 const { api } = createFetch({ logger });
 ```
 
-See [`@zap-studio/logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.
+See [`logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.

--- a/apps/docs/content/fetch/meta.ts
+++ b/apps/docs/content/fetch/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/fetch",
+  title: "fetch",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/fetch/opentelemetry.mdx
+++ b/apps/docs/content/fetch/opentelemetry.mdx
@@ -63,4 +63,4 @@ Span creation and attribute-setting always work everywhere, regardless of this. 
 
 ## Log Correlation
 
-Pair this with [`@zap-studio/logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so a request's spans and logs line up in whatever backend you send them to.
+Pair this with [`logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so a request's spans and logs line up in whatever backend you send them to.

--- a/apps/docs/content/fetch/validated-fetch-mode.mdx
+++ b/apps/docs/content/fetch/validated-fetch-mode.mdx
@@ -39,7 +39,7 @@ function $fetch<TSchema extends StandardSchemaV1>(
 ): Promise<StandardSchemaV1.Result<StandardSchemaV1.InferOutput<TSchema>>>;
 ```
 
-- `schema` — any object implementing Standard Schema (Zod, Valibot, ArkType, ...), exported as `StandardSchemaV1` from `@zap-studio/validation`.
+- `schema` — any object implementing Standard Schema (Zod, Valibot, ArkType, ...), exported as `StandardSchemaV1` from `validation`.
 
 ## Options
 

--- a/apps/docs/content/fetch/validation.mdx
+++ b/apps/docs/content/fetch/validation.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/fetch"
 ---
 
-Response validation works with any library that implements Standard Schema. `@zap-studio/fetch` validates responses through [`@zap-studio/validation`](/validation), so any [Standard Schema](https://standardschema.dev/schema)-compatible validator can be used.
+Response validation works with any library that implements Standard Schema. `fetch` validates responses through [`validation`](/validation), so any [Standard Schema](https://standardschema.dev/schema)-compatible validator can be used.
 
 :::note
 
@@ -69,7 +69,7 @@ const UserSchema = type({
 
 ## Throwing Mode
 
-By default (`throwOnValidationError: true`), a `ValidationError` is thrown when the response does not match the schema. Import it from `@zap-studio/validation`.
+By default (`throwOnValidationError: true`), a `ValidationError` is thrown when the response does not match the schema. Import it from `validation`.
 
 ```ts
 import { api } from "@zap-studio/fetch";
@@ -138,7 +138,7 @@ const user = await api.post("https://api.example.com/users", UserSchema, {
 
 ## Standalone Validation
 
-For validation outside HTTP requests, use [`@zap-studio/validation`](/validation) directly. It also exports the `StandardSchemaV1` type when you need to type schema parameters yourself.
+For validation outside HTTP requests, use [`validation`](/validation) directly. It also exports the `StandardSchemaV1` type when you need to type schema parameters yourself.
 
 ```ts
 import { standardValidate } from "@zap-studio/validation";

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -5,20 +5,12 @@ sidebar:
   label: Getting Started
 ---
 
-[![CI](https://github.com/zap-studio/monorepo/actions/workflows/ci.yml/badge.svg)](https://github.com/zap-studio/monorepo/actions/workflows/ci.yml) [![License](https://img.shields.io/github/license/zap-studio/monorepo)](https://github.com/zap-studio/monorepo/blob/main/LICENSE)
-
 Small, type-safe TypeScript packages for the infrastructure code every app needs — HTTP calls, retries, auth checks, validation, logging, webhooks. Done once, correctly, so you don't rebuild it per project.
-
-```bash
-npm install fetch
-```
-
-[Start with `fetch` →](/fetch/getting-started)
 
 ## Quick Look
 
 ```ts
-import { api } from "fetch";
+import { api } from "@zap-studio/fetch";
 import { z } from "zod";
 
 const UserSchema = z.object({

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -5,8 +5,6 @@ sidebar:
   label: Getting Started
 ---
 
-Small, type-safe TypeScript packages for the infrastructure code every app needs — HTTP calls, retries, auth checks, validation, logging, webhooks. Done once, correctly, so you don't rebuild it per project.
-
 ## Quick Look
 
 ```ts

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 Small, type-safe TypeScript packages for the infrastructure code every app needs — HTTP calls, retries, auth checks, validation, logging, webhooks. Done once, correctly, so you don't rebuild it per project.
 
 ```bash
-npm install @zap-studio/fetch
+npm install fetch
 ```
 
 [Start with `fetch` →](/fetch/getting-started)
@@ -18,7 +18,7 @@ npm install @zap-studio/fetch
 ## Quick Look
 
 ```ts
-import { api } from "@zap-studio/fetch";
+import { api } from "fetch";
 import { z } from "zod";
 
 const UserSchema = z.object({
@@ -33,22 +33,22 @@ const user = await api.get("https://api.example.com/users/1", UserSchema);
 
 ## Packages
 
-| Package                                   | What you get                                                      |
-| ----------------------------------------- | ----------------------------------------------------------------- |
-| [`@zap-studio/cache`](/cache)             | An in-memory cache with pluggable eviction and optional TTL       |
-| [`@zap-studio/env`](/env)                 | Typed, validated env vars with a server/client/shared split       |
-| [`@zap-studio/fetch`](/fetch)             | Typed responses from any API — no manual casts                    |
-| [`@zap-studio/logger`](/logger)           | Structured logs anywhere — console today, any backend tomorrow    |
-| [`@zap-studio/monads`](/monads)           | Errors as values you can't forget to handle                       |
-| [`@zap-studio/oxfmt`](/oxfmt)             | One decided import/`package.json` order — no more per-repo debate |
-| [`@zap-studio/oxlint`](/oxlint)           | A preset per stack, zero-config linting beyond oxlint's defaults  |
-| [`@zap-studio/permit`](/permit)           | Every permission check in one auditable place                     |
-| [`@zap-studio/react-hooks`](/react-hooks) | Small, focused, tree-shakeable React hooks                        |
-| [`@zap-studio/retry`](/retry)             | Retries done right — backoff, jitter, cancellation included       |
-| [`@zap-studio/store`](/store)             | State with derived values that auto-track, and built-in persist   |
-| [`@zap-studio/validation`](/validation)   | One validation error shape, whatever schema library you use       |
-| [`@zap-studio/webhooks`](/webhooks)       | Verified, routed webhooks without a hand-rolled signature check   |
-| [`@zap-studio/webmcp`](/webmcp)           | SSR-safe tool registration for the native WebMCP browser API      |
+| Package                       | What you get                                                      |
+| ----------------------------- | ----------------------------------------------------------------- |
+| [`cache`](/cache)             | An in-memory cache with pluggable eviction and optional TTL       |
+| [`env`](/env)                 | Typed, validated env vars with a server/client/shared split       |
+| [`fetch`](/fetch)             | Typed responses from any API — no manual casts                    |
+| [`logger`](/logger)           | Structured logs anywhere — console today, any backend tomorrow    |
+| [`monads`](/monads)           | Errors as values you can't forget to handle                       |
+| [`oxfmt`](/oxfmt)             | One decided import/`package.json` order — no more per-repo debate |
+| [`oxlint`](/oxlint)           | A preset per stack, zero-config linting beyond oxlint's defaults  |
+| [`permit`](/permit)           | Every permission check in one auditable place                     |
+| [`react-hooks`](/react-hooks) | Small, focused, tree-shakeable React hooks                        |
+| [`retry`](/retry)             | Retries done right — backoff, jitter, cancellation included       |
+| [`store`](/store)             | State with derived values that auto-track, and built-in persist   |
+| [`validation`](/validation)   | One validation error shape, whatever schema library you use       |
+| [`webhooks`](/webhooks)       | Verified, routed webhooks without a hand-rolled signature check   |
+| [`webmcp`](/webmcp)           | SSR-safe tool registration for the native WebMCP browser API      |
 
 Install only the packages you need — each one works standalone.
 

--- a/apps/docs/content/logger/formats.mdx
+++ b/apps/docs/content/logger/formats.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/logger"
 ---
 
-`ConsoleLogger` accepts a `format?: LogFormatter` option, defaulting to `classicFormat` — today's `message` + `context` output. Built-in formatters are all exported from `@zap-studio/logger` (and the dedicated `@zap-studio/logger/format` subpath).
+`ConsoleLogger` accepts a `format?: LogFormatter` option, defaulting to `classicFormat` — today's `message` + `context` output. Built-in formatters are all exported from `logger` (and the dedicated `@zap-studio/logger/format` subpath).
 
 ```ts
 import { ConsoleLogger, jsonFormat } from "@zap-studio/logger";

--- a/apps/docs/content/logger/getting-started.mdx
+++ b/apps/docs/content/logger/getting-started.mdx
@@ -62,7 +62,7 @@ const silentLogger = new ConsoleLogger({ minLevel: "none" });
 
 ## Passing a Logger to Other Packages
 
-`@zap-studio/retry`, `@zap-studio/fetch`, `@zap-studio/webhooks`, and `@zap-studio/permit` all accept an optional `logger?: Logger` option. Passing nothing means no logging overhead at all — the package never calls into a logger it wasn't given.
+`retry`, `fetch`, `webhooks`, and `permit` all accept an optional `logger?: Logger` option. Passing nothing means no logging overhead at all — the package never calls into a logger it wasn't given.
 
 ```ts
 import { ConsoleLogger } from "@zap-studio/logger";

--- a/apps/docs/content/logger/index.mdx
+++ b/apps/docs/content/logger/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/logger"
+title: logger
 description: A lean logging abstraction with a console implementation.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/logger"
 ---
 
-`@zap-studio/logger` gives `@zap-studio/*` packages (and your own code) an optional, pluggable way to emit logs — one interface, one console-backed implementation, with next to no dependency weight.
+`logger` gives `@zap-studio/*` packages (and your own code) an optional, pluggable way to emit logs — one interface, one console-backed implementation, with next to no dependency weight.
 
 ## Motivation
 
@@ -15,7 +15,7 @@ Libraries like `winston` and `pino` are built for Node servers, with file transp
 
 This becomes a problem for small libraries that want to add logging: if a retry library or an HTTP client hard-depends on `winston`, every user of that library must install `winston`, even if they do not want logging, and even if their code runs somewhere `winston` does not.
 
-`@zap-studio/logger` avoids this by shipping an interface, not an implementation. `Logger` is a small type with six methods (`trace`, `debug`, `info`, `warn`, `error`, `fatal`). Most `@zap-studio/*` packages that talk to the outside world — `fetch`, `permit`, `retry`, `webhooks` — accept an optional `logger: Logger`.
+`logger` avoids this by shipping an interface, not an implementation. `Logger` is a small type with six methods (`trace`, `debug`, `info`, `warn`, `error`, `fatal`). Most `@zap-studio/*` packages that talk to the outside world — `fetch`, `permit`, `retry`, `webhooks` — accept an optional `logger: Logger`.
 
 Pass nothing, and there is no dependency and no runtime cost. Pass `ConsoleLogger`, and you get leveled, formatted output that works on Node, Bun, Deno, browsers, and Cloudflare Workers with no setup.
 

--- a/apps/docs/content/logger/meta.ts
+++ b/apps/docs/content/logger/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/logger",
+  title: "logger",
   display: "page",
   pages: ["getting-started", "formats", "runtime-compatibility", "opentelemetry"],
 });

--- a/apps/docs/content/logger/runtime-compatibility.mdx
+++ b/apps/docs/content/logger/runtime-compatibility.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/logger"
 ---
 
-`@zap-studio/logger` works out of the box on Node.js, Bun, Deno, browsers, and Cloudflare Workers — no configuration needed.
+`logger` works out of the box on Node.js, Bun, Deno, browsers, and Cloudflare Workers — no configuration needed.
 
 `console` dispatch, level filtering, `classicFormat`, `jsonFormat`, and `compactFormat` have no runtime-specific code at all. The only per-runtime behavior is [`prettyFormat`](/logger/formats)'s color detection:
 

--- a/apps/docs/content/monads/index.mdx
+++ b/apps/docs/content/monads/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/monads"
+title: monads
 description: Result/Option types and Rust-style functional combinators for explicit, type-safe error handling.
 sidebar:
   label: Overview
@@ -7,13 +7,13 @@ type: package
 package: "@zap-studio/monads"
 ---
 
-`@zap-studio/monads` provides `Result`, `ResultAsync`, and `Option` types with Rust-style functional combinators — an explicit, type-safe alternative to throw/catch and nullable checks.
+`monads` provides `Result`, `ResultAsync`, and `Option` types with Rust-style functional combinators — an explicit, type-safe alternative to throw/catch and nullable checks.
 
 ## Motivation
 
 Hand-rolled `{ ok: boolean, ... }` result shapes and nullable checks are easy to write once and painful to keep consistent across a codebase. Libraries like [neverthrow](https://github.com/supermacro/neverthrow) and [Effect](https://effect.website/) solve this well, but pull in more surface (do-notation, a runtime, generators, `Either`, class-based fluent APIs) than most projects need.
 
-`@zap-studio/monads` is deliberately small: `Result`, `ResultAsync`, and `Option`, as standalone, tree-shakeable functions composed with `pipe` — not class instances with chained methods.
+`monads` is deliberately small: `Result`, `ResultAsync`, and `Option`, as standalone, tree-shakeable functions composed with `pipe` — not class instances with chained methods.
 
 ## Features
 

--- a/apps/docs/content/monads/meta.ts
+++ b/apps/docs/content/monads/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/monads",
+  title: "monads",
   display: "page",
   pages: ["getting-started", "result", "result-async", "option", "pipe"],
 });

--- a/apps/docs/content/oxfmt/index.mdx
+++ b/apps/docs/content/oxfmt/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/oxfmt"
+title: oxfmt
 description: A decided oxfmt preset for sorted imports, sorted package.json, and optional Tailwind CSS class sorting.
 sidebar:
   label: Overview
@@ -7,13 +7,13 @@ type: package
 package: "@zap-studio/oxfmt"
 ---
 
-`@zap-studio/oxfmt` is Zap Studio's [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) preset — sorted imports, sorted `package.json`, and an optional Tailwind CSS class-sorting extension.
+`oxfmt` is Zap Studio's [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) preset — sorted imports, sorted `package.json`, and an optional Tailwind CSS class-sorting extension.
 
 ## Motivation
 
 `oxfmt`'s `sortImports` option is powerful but unopinionated — it asks you to define your own group order, and most projects either skip it or improvise one per repo, so import order drifts between packages in the same monorepo and every PR review re-litigates it.
 
-`@zap-studio/oxfmt` ships one decided order: type-only imports first, then builtin/external values, then internal types, then internal values, then parent/sibling/index imports grouped by type then value, then anything unmatched — with a blank line between each group. `package.json` is sorted the same way every time, keys and `scripts` alphabetically. Adopt the preset once and stop deciding it per project.
+`oxfmt` ships one decided order: type-only imports first, then builtin/external values, then internal types, then internal values, then parent/sibling/index imports grouped by type then value, then anything unmatched — with a blank line between each group. `package.json` is sorted the same way every time, keys and `scripts` alphabetically. Adopt the preset once and stop deciding it per project.
 
 ## Features
 

--- a/apps/docs/content/oxfmt/meta.ts
+++ b/apps/docs/content/oxfmt/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/oxfmt",
+  title: "oxfmt",
   display: "page",
   pages: ["getting-started", "presets"],
 });

--- a/apps/docs/content/oxlint/anti-slop.mdx
+++ b/apps/docs/content/oxlint/anti-slop.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/oxlint"
 ---
 
-`anti-slop` is bundled directly in `@zap-studio/oxlint`, not wrapped from an upstream ESLint plugin. It's included in [`base`](/oxlint/presets) — and therefore every preset built on it — and catches patterns that lose type evidence or swap a real implementation for something that only looks like one.
+`anti-slop` is bundled directly in `oxlint`, not wrapped from an upstream ESLint plugin. It's included in [`base`](/oxlint/presets) — and therefore every preset built on it — and catches patterns that lose type evidence or swap a real implementation for something that only looks like one.
 
 ## Rules
 

--- a/apps/docs/content/oxlint/index.mdx
+++ b/apps/docs/content/oxlint/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/oxlint"
+title: oxlint
 description: "Exclusive, single-owner oxlint presets — pick exactly the plugins and framework rules your project needs, nothing implied."
 sidebar:
   label: Overview
@@ -7,13 +7,13 @@ type: package
 package: "@zap-studio/oxlint"
 ---
 
-`@zap-studio/oxlint` is Zap Studio's [oxlint](https://oxc.rs/docs/guide/usage/linter.html) preset — exclusive, single-owner rule sets built from vetted ESLint plugins, plus a bundled `anti-slop` plugin.
+`oxlint` is Zap Studio's [oxlint](https://oxc.rs/docs/guide/usage/linter.html) preset — exclusive, single-owner rule sets built from vetted ESLint plugins, plus a bundled `anti-slop` plugin.
 
 ## Motivation
 
 `oxlint` runs zero-config out of the box, but that config only covers its own bundled rules. The moment a project needs React, Next.js, TanStack, or test-specific linting, that zero-config story ends — now it's on you to find the right plugins, wire them up, and decide which rules to turn on.
 
-`@zap-studio/oxlint` picks up where zero-config leaves off: one preset per plugin or framework integration, each owning a disjoint slice of rules. Nothing cascades — `extends: [react]` gets you the `react` plugin's hooks rules and nothing else, not accessibility, not React-Doctor's broader catalog, not any particular framework. You list every preset you want.
+`oxlint` picks up where zero-config leaves off: one preset per plugin or framework integration, each owning a disjoint slice of rules. Nothing cascades — `extends: [react]` gets you the `react` plugin's hooks rules and nothing else, not accessibility, not React-Doctor's broader catalog, not any particular framework. You list every preset you want.
 
 The one exception is `base`: JS/TS correctness and security rules that apply regardless of framework, bundled as a single preset since there's no meaningful way to want half of it.
 

--- a/apps/docs/content/oxlint/meta.ts
+++ b/apps/docs/content/oxlint/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/oxlint",
+  title: "oxlint",
   display: "page",
   pages: ["getting-started", "presets", "plugins", "anti-slop"],
 });

--- a/apps/docs/content/oxlint/plugins.mdx
+++ b/apps/docs/content/oxlint/plugins.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/oxlint"
 ---
 
-Every rule in `@zap-studio/oxlint` traces back to one of two places: a plugin **built into oxlint itself** (ported from an upstream ESLint plugin into Rust, and run natively), or an **external ESLint plugin** loaded through `jsPlugins` and run as real JS. This page lists both, with a link to the upstream source and a link to the file in this repo where the rule is turned on or off — every `"off"` entry carries a comment explaining why, so you never have to guess.
+Every rule in `oxlint` traces back to one of two places: a plugin **built into oxlint itself** (ported from an upstream ESLint plugin into Rust, and run natively), or an **external ESLint plugin** loaded through `jsPlugins` and run as real JS. This page lists both, with a link to the upstream source and a link to the file in this repo where the rule is turned on or off — every `"off"` entry carries a comment explaining why, so you never have to guess.
 
 ## Built into oxlint
 

--- a/apps/docs/content/permit/index.mdx
+++ b/apps/docs/content/permit/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/permit"
+title: permit
 description: A type-safe, declarative authorization library for TypeScript with Standard Schema validation and composable conditions.
 sidebar:
   label: Overview
@@ -15,7 +15,7 @@ Authorization checks written by hand, like `if (user.role === "admin")`, spread 
 
 A framework like CASL solves the spreading problem, but it comes with its own vocabulary to learn (`subject`, `can`, `cannot`, `rules`), and its rules are not checked against your actual data shapes — you can write a rule that references a field your resource does not have, and it will only fail once that code runs.
 
-`@zap-studio/permit` keeps all rules in one place, through `createPolicy(...)` with `allow()`, `deny()`, and `when(condition)` — one file answers "who can do what."
+`permit` keeps all rules in one place, through `createPolicy(...)` with `allow()`, `deny()`, and `when(condition)` — one file answers "who can do what."
 
 And because resources come from your Standard Schema schemas, policy types are derived straight from your real data shapes. Reference a field that does not exist, and you get an error while writing the code, not a silent `undefined` in production.
 
@@ -28,7 +28,7 @@ And because resources come from your Standard Schema schemas, policy types are d
 - **Composable conditions** via `and`, `or`, and `not`. See [Conditions](/permit/conditions).
 - **Policy merging strategies** via `mergePoliciesAnd` and `mergePoliciesOr`. See [Merging Policies](/permit/merging-policies).
 - **Structured errors** with `PolicyError` for invalid configuration or evaluation failures. See [Error Handling](/permit/errors).
-- **[Optional logging](/permit/logging)** through `createPolicy({ logger })` from [`@zap-studio/logger`](/logger) — omit it and there's zero added logging overhead.
+- **[Optional logging](/permit/logging)** through `createPolicy({ logger })` from [`logger`](/logger) — omit it and there's zero added logging overhead.
 - **[Native OpenTelemetry](/permit/opentelemetry)** — an `INTERNAL` span per check with the allow/deny decision as an attribute, plus a `permit.checks` counter, no-op until an SDK is registered.
 - **Tree-shakeable** — policies and conditions are plain functions; unused exports are dropped by any modern bundler.
 

--- a/apps/docs/content/permit/logging.mdx
+++ b/apps/docs/content/permit/logging.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/permit"
 ---
 
-`createPolicy(...)` accepts an optional `logger?: Logger` option from [`@zap-studio/logger`](/logger). Pass one to observe policy evaluation; omit it and only the pre-existing internal-error warnings still print, unchanged.
+`createPolicy(...)` accepts an optional `logger?: Logger` option from [`logger`](/logger). Pass one to observe policy evaluation; omit it and only the pre-existing internal-error warnings still print, unchanged.
 
 ```ts
 import { ConsoleLogger } from "@zap-studio/logger";
@@ -47,4 +47,4 @@ const logger: Logger = {
 const policy = createPolicy({ resources, actions, rules, logger });
 ```
 
-See [`@zap-studio/logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.
+See [`logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.

--- a/apps/docs/content/permit/meta.ts
+++ b/apps/docs/content/permit/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/permit",
+  title: "permit",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/permit/opentelemetry.mdx
+++ b/apps/docs/content/permit/opentelemetry.mdx
@@ -53,4 +53,4 @@ A `permit.checks` counter is incremented alongside every span, tagged with the s
 
 ## Log Correlation
 
-Pair this with [`@zap-studio/logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so the allow/deny logs from [the `logger` option](/permit/logging) line up with the check spans.
+Pair this with [`logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so the allow/deny logs from [the `logger` option](/permit/logging) line up with the check spans.

--- a/apps/docs/content/react-hooks/index.mdx
+++ b/apps/docs/content/react-hooks/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/react-hooks"
+title: react-hooks
 description: "Small, focused, tree-shakeable React hooks — one hook, one subpath, no forced bundle."
 sidebar:
   label: Overview
@@ -7,13 +7,13 @@ type: package
 package: "@zap-studio/react-hooks"
 ---
 
-`@zap-studio/react-hooks` is a collection of 100+ small, focused React hooks. Each hook ships as its own subpath export — importing one never pulls in unrelated hooks — with SSR-safe defaults and 100% test coverage.
+`react-hooks` is a collection of 100+ small, focused React hooks. Each hook ships as its own subpath export — importing one never pulls in unrelated hooks — with SSR-safe defaults and 100% test coverage.
 
 ## Motivation
 
 Reaching a browser API from React usually means hand-writing a `useEffect` — a resize listener, a `matchMedia` subscription, an `IntersectionObserver` — and each one carries the same two risks: forget the cleanup and you get a leaked listener that keeps firing after unmount, or forget to guard `window`/`document`/`navigator` and the same code throws on the server or hydrates to a value the client's first render did not have.
 
-`@zap-studio/react-hooks` wraps these APIs — `IntersectionObserver`, `ResizeObserver`, the Battery/Geolocation/Share/Wake Lock APIs, `matchMedia`, and more — behind a small, correct React interface instead of code you write from scratch. Every hook is SSR- and hydration-safe: nothing touches `window`, `document`, or `navigator` outside an effect or a guarded check, so server renders never throw and hydration never mismatches.
+`react-hooks` wraps these APIs — `IntersectionObserver`, `ResizeObserver`, the Battery/Geolocation/Share/Wake Lock APIs, `matchMedia`, and more — behind a small, correct React interface instead of code you write from scratch. Every hook is SSR- and hydration-safe: nothing touches `window`, `document`, or `navigator` outside an effect or a guarded check, so server renders never throw and hydration never mismatches.
 
 Every hook also ships as its own standalone, side-effect-free module — import it on its own and it tree-shakes cleanly. Public hooks never import each other; some share small internal helper modules, so pulling in `useIsMobile` never drags in unrelated hook code.
 

--- a/apps/docs/content/react-hooks/meta.ts
+++ b/apps/docs/content/react-hooks/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/react-hooks",
+  title: "react-hooks",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/retry/errors.mdx
+++ b/apps/docs/content/retry/errors.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/retry"
 ---
 
-`@zap-studio/retry` throws two structured terminal errors: `RetryError` on exhaustion and `AbortError` on cancellation. Both extend `Error`.
+`retry` throws two structured terminal errors: `RetryError` on exhaustion and `AbortError` on cancellation. Both extend `Error`.
 
 ## Import
 

--- a/apps/docs/content/retry/getting-started.mdx
+++ b/apps/docs/content/retry/getting-started.mdx
@@ -69,7 +69,7 @@ const users = await runRetryPolicy(policy, async () => {
 
 :::note
 
-The example uses [`@zap-studio/fetch`](/fetch), but any function that returns a promise works — the runner retries whenever the function throws or rejects.
+The example uses [`fetch`](/fetch), but any function that returns a promise works — the runner retries whenever the function throws or rejects.
 
 :::
 

--- a/apps/docs/content/retry/index.mdx
+++ b/apps/docs/content/retry/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/retry"
+title: retry
 description: Composable retry policies with a built-in runner, structured terminal errors, and AbortSignal cancellation.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/retry"
 ---
 
-`@zap-studio/retry` gives you reusable retry policies and a built-in runner so you can add resilient retries to async operations without rewriting orchestration loops.
+`retry` gives you reusable retry policies and a built-in runner so you can add resilient retries to async operations without rewriting orchestration loops.
 
 ## Motivation
 
@@ -15,7 +15,7 @@ A hand-written retry loop is usually a `for` loop with `setTimeout`, and it is e
 
 Without cancellation, a retry loop can keep running — and keep hitting the network — after the result is no longer needed, for example after a user navigates away.
 
-`@zap-studio/retry` gives you this behavior as a built-in option, instead of something you write from scratch. `exponentialBackoff` and `linearBackoff` support jitter (`"full"` or `"equal"`, the same strategies AWS recommends) through the `jitter` option — turn it on and delays are randomized instead of fixed.
+`retry` gives you this behavior as a built-in option, instead of something you write from scratch. `exponentialBackoff` and `linearBackoff` support jitter (`"full"` or `"equal"`, the same strategies AWS recommends) through the `jitter` option — turn it on and delays are randomized instead of fixed.
 
 Every retry loop also accepts an `AbortSignal`, checked before each attempt and while waiting between attempts, so an abort stops the next attempt or delay from starting; it does not interrupt an attempt that is already running. You get retry policies as values you configure once and reuse, instead of logic you have to get right from scratch in every project.
 
@@ -28,7 +28,7 @@ Every retry loop also accepts an `AbortSignal`, checked before each attempt and 
 - **Non-throw mode** ([`throwOnExhausted: false`](/retry/non-throw-mode)) returns a `RetryRunResult` instead of throwing.
 - **Cancellation** through [`AbortSignal`](/retry/abort-signal), checked before, between, and during retries.
 - **Custom policies** as [plain objects implementing `RetryPolicy`](/retry/custom-policies) — just a `next(...)` function, no subclassing.
-- **[Optional logging](/retry/logging)** via a `logger?: Logger` option from [`@zap-studio/logger`](/logger) — omit it and there's zero logging overhead.
+- **[Optional logging](/retry/logging)** via a `logger?: Logger` option from [`logger`](/logger) — omit it and there's zero logging overhead.
 - **[Native OpenTelemetry](/retry/opentelemetry)** — retry decisions as events on the caller's active span, plus a `retry.attempts` counter, no-op until an SDK is registered.
 - **Tree-shakeable** — policies are functions returning plain objects, not classes; unused policies are dropped by any modern bundler.
 

--- a/apps/docs/content/retry/logging.mdx
+++ b/apps/docs/content/retry/logging.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/retry"
 ---
 
-`runRetryPolicy(...)` accepts an optional `logger?: Logger` option from [`@zap-studio/logger`](/logger). Pass one to observe retry internals; omit it and nothing is logged — zero overhead.
+`runRetryPolicy(...)` accepts an optional `logger?: Logger` option from [`logger`](/logger). Pass one to observe retry internals; omit it and nothing is logged — zero overhead.
 
 ```ts
 import { ConsoleLogger } from "@zap-studio/logger";
@@ -46,4 +46,4 @@ const logger: Logger = {
 await runRetryPolicy(policy, execute, { logger });
 ```
 
-See [`@zap-studio/logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.
+See [`logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.

--- a/apps/docs/content/retry/meta.ts
+++ b/apps/docs/content/retry/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/retry",
+  title: "retry",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/retry/opentelemetry.mdx
+++ b/apps/docs/content/retry/opentelemetry.mdx
@@ -45,7 +45,7 @@ await runRetryPolicy(policy, execute);
 
 Unlike [`fetch`](/fetch/opentelemetry), [`webhooks`](/webhooks/opentelemetry), and [`permit`](/permit/opentelemetry), this package never creates its own span. A retry loop wraps someone else's operation — usually a network call that's already producing its own span — so a whole extra span per attempt would just be noise nested inside that operation's span.
 
-Instead, each retry decision is recorded as an **event** on whatever span is already active when the decision happens (for example, the `CLIENT` span from a `@zap-studio/fetch` call being retried, or your own app-level span):
+Instead, each retry decision is recorded as an **event** on whatever span is already active when the decision happens (for example, the `CLIENT` span from a `fetch` call being retried, or your own app-level span):
 
 | Event             | When                        | Attributes                                  |
 | ----------------- | --------------------------- | ------------------------------------------- |
@@ -60,4 +60,4 @@ Every decision also increments a `retry.attempts` counter, tagged with `retry.de
 
 ## Log Correlation
 
-Pair this with [`@zap-studio/logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so retry decisions logged via [the `logger` option](/retry/logging) line up with the events on the active span.
+Pair this with [`logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so retry decisions logged via [the `logger` option](/retry/logging) line up with the events on the active span.

--- a/apps/docs/content/retry/running-policies.mdx
+++ b/apps/docs/content/retry/running-policies.mdx
@@ -38,7 +38,7 @@ const value = await runRetryPolicy(policy, async (attempt) => {
 
 ## Custom Sleep
 
-By default, delays use `defaultSleep` (a `setTimeout`-based helper exported from `@zap-studio/retry`). Inject your own `sleep` for deterministic tests or custom timing.
+By default, delays use `defaultSleep` (a `setTimeout`-based helper exported from `retry`). Inject your own `sleep` for deterministic tests or custom timing.
 
 ```ts
 const value = await runRetryPolicy(

--- a/apps/docs/content/store/index.mdx
+++ b/apps/docs/content/store/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/store"
+title: store
 description: A small, framework-agnostic state container with auto-tracked derived values and optional built-in persist.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/store"
 ---
 
-`@zap-studio/store` is a small, framework-agnostic state container with auto-tracked derived values and simple built-in persist. It works with any framework, or no framework at all.
+`store` is a small, framework-agnostic state container with auto-tracked derived values and simple built-in persist. It works with any framework, or no framework at all.
 
 ## Motivation
 
@@ -17,7 +17,7 @@ Jotai's atom model is nice, but `jotai/utils` alone has more than a dozen helper
 
 TanStack Store has the best reactive core of the three. It uses an auto-tracked signal graph, so derived values only recompute when a real dependency changes. But `subscribe()` returns an object shaped like RxJS's `Subscription`, not a plain function. It also has no built-in persistence.
 
-`@zap-studio/store` takes TanStack's auto-tracked reactivity and Zustand's simple, single-factory style. The public API stays small on purpose: `createStore`, `derive`, and nothing else. No middleware chain, no Provider, no atom zoo.
+`store` takes TanStack's auto-tracked reactivity and Zustand's simple, single-factory style. The public API stays small on purpose: `createStore`, `derive`, and nothing else. No middleware chain, no Provider, no atom zoo.
 
 ## Features
 

--- a/apps/docs/content/store/meta.ts
+++ b/apps/docs/content/store/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/store",
+  title: "store",
   display: "page",
   pages: ["getting-started", "set", "derive", "persist", "react"],
 });

--- a/apps/docs/content/store/react.mdx
+++ b/apps/docs/content/store/react.mdx
@@ -64,7 +64,7 @@ const increment = useStore(counter, (s) => s.increment);
 
 ## Prefer `derive` Over Manual Equality Checks
 
-Zustand's React binding needs a `selector` plus a manual `shallow` comparison to avoid re-rendering when a selector returns a new object or array every time. `@zap-studio/store` solves this at the source instead: build the exact value you need with `derive`, which caches its result and only changes reference when the value itself changes.
+Zustand's React binding needs a `selector` plus a manual `shallow` comparison to avoid re-rendering when a selector returns a new object or array every time. `store` solves this at the source instead: build the exact value you need with `derive`, which caches its result and only changes reference when the value itself changes.
 
 ```tsx
 // Prefer this — derive() caches the computed object:

--- a/apps/docs/content/store/set.mdx
+++ b/apps/docs/content/store/set.mdx
@@ -48,7 +48,7 @@ const counter = createStore({ count: 5 }, (set, get) => ({
 
 Zustand's `setState` accepts both a partial object and an updater function, and merges either way. That flexibility hides a real ambiguity: does `set({ count: 1 })` merge `count` into the existing state, or replace the whole state with `{ count: 1 }`? Zustand answers "merge," but that answer is not visible at the call site — you have to know the library's convention.
 
-`@zap-studio/store` removes the ambiguity by only accepting the updater form. It stays a one-liner for simple updates (`set(() => ({ count: 1 }))`), and every call site is unambiguous about being a merge.
+`store` removes the ambiguity by only accepting the updater form. It stays a one-liner for simple updates (`set(() => ({ count: 1 }))`), and every call site is unambiguous about being a merge.
 
 ## Nested State Is Not Deep-Merged
 
@@ -64,7 +64,7 @@ const form = createStore({ user: { name: "Ada", age: 30 } }, (set) => ({
 }));
 ```
 
-This is the same rule Zustand and most state containers follow — it is called out here because `@zap-studio/store` removing the bare-object overload does not change it.
+This is the same rule Zustand and most state containers follow — it is called out here because `store` removing the bare-object overload does not change it.
 
 ## See Also
 

--- a/apps/docs/content/validation/errors.mdx
+++ b/apps/docs/content/validation/errors.mdx
@@ -20,7 +20,7 @@ When `throwOnError` is `false` or omitted, the helpers never throw for invalid i
 
 ## Catch ValidationError
 
-Import `ValidationError` from `@zap-studio/validation` and check with `instanceof`.
+Import `ValidationError` from `validation` and check with `instanceof`.
 
 ```ts
 import { standardValidate, ValidationError } from "@zap-studio/validation";

--- a/apps/docs/content/validation/index.mdx
+++ b/apps/docs/content/validation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/validation"
+title: validation
 description: Standard Schema utilities and ValidationError helpers for one consistent validation flow across schema libraries.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/validation"
 ---
 
-`@zap-studio/validation` provides utilities for validating values using the [**Standard Schema**](https://standardschema.dev/schema) specification.
+`validation` provides utilities for validating values using the [**Standard Schema**](https://standardschema.dev/schema) specification.
 
 ## Motivation
 
@@ -15,7 +15,7 @@ Zod throws a `ZodError`. Valibot returns a result object. ArkType has its own sh
 
 And if you ever switch from one to another, every call site that touches validation needs to change too.
 
-`@zap-studio/validation` removes this difference. `standardValidate` and `standardValidateSync` give you one function and one `ValidationError` shape, no matter which Standard Schema library sits underneath.
+`validation` removes this difference. `standardValidate` and `standardValidateSync` give you one function and one `ValidationError` shape, no matter which Standard Schema library sits underneath.
 
 Validation code becomes portable: swap the schema library later, and the code that calls it does not need to change.
 

--- a/apps/docs/content/validation/meta.ts
+++ b/apps/docs/content/validation/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/validation",
+  title: "validation",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/webhooks/index.mdx
+++ b/apps/docs/content/webhooks/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/webhooks"
+title: webhooks
 description: Schema-first, type-safe webhook routing built on the standard Web API Request and Response primitives, with runtime-agnostic signature verification support.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/webhooks"
 ---
 
-`@zap-studio/webhooks` is schema-first, type-safe webhook routing built on the standard Web API [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) primitives, with runtime-agnostic signature verification support.
+`webhooks` is schema-first, type-safe webhook routing built on the standard Web API [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) primitives, with runtime-agnostic signature verification support.
 
 ## Motivation
 
@@ -15,7 +15,7 @@ Webhook endpoints are usually built by hand, per provider, and this tends to rep
 
 Second, signatures are often compared with `===`, which leaks timing information and opens a timing-attack risk that most teams do not know they have.
 
-`@zap-studio/webhooks` fixes both. It is built on the standard `Request`/`Response` objects, so the same router works on Bun, Deno, Cloudflare Workers, or any framework that accepts a `Request`.
+`webhooks` fixes both. It is built on the standard `Request`/`Response` objects, so the same router works on Bun, Deno, Cloudflare Workers, or any framework that accepts a `Request`.
 
 Signature verification is opt-in through the `verify` option, and the built-in HMAC verifier uses the Web Crypto API (`globalThis.crypto.subtle`) with a constant-time comparison, so once you turn it on, you get the safe comparison without writing it yourself. Payloads are validated and typed straight from your Standard Schema — no `any` from `JSON.parse`, no manual casts.
 
@@ -27,7 +27,7 @@ Signature verification is opt-in through the `verify` option, and the built-in H
 - **Signature verification** — built-in HMAC verifier with constant-time comparison, or plug in your own `verify` function.
 - **Lifecycle hooks** — global `before`, `after`, and `onError` hooks for cross-cutting behavior.
 - **Runtime-agnostic** — uses the Web Crypto API, not Node-specific APIs.
-- **[Optional logging](/webhooks/logging)** through `createWebhookRouter({ logger })` from [`@zap-studio/logger`](/logger) — omit it and there's zero logging overhead.
+- **[Optional logging](/webhooks/logging)** through `createWebhookRouter({ logger })` from [`logger`](/logger) — omit it and there's zero logging overhead.
 - **[Native OpenTelemetry](/webhooks/opentelemetry)** — a `SERVER` span per delivery continuing the sender's trace, plus a child span per handler dispatch, no-op until an SDK is registered.
 - **Tree-shakeable** — validation and hook-running internals are standalone functions; unused exports are dropped by any modern bundler.
 

--- a/apps/docs/content/webhooks/lifecycle-hooks.mdx
+++ b/apps/docs/content/webhooks/lifecycle-hooks.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/webhooks"
 ---
 
-`@zap-studio/webhooks` exposes global `before`, `after`, and `onError` hooks for cross-cutting behavior. Hooks are shared interception points around route execution — they keep handlers focused on business logic while logging, metrics, and error policy live in one place.
+`webhooks` exposes global `before`, `after`, and `onError` hooks for cross-cutting behavior. Hooks are shared interception points around route execution — they keep handlers focused on business logic while logging, metrics, and error policy live in one place.
 
 ## Add Global Hooks
 
@@ -27,7 +27,7 @@ const router = createWebhookRouter({
 
 Every hook receives the webhook context — `{ request, rawBody, path }` — where `request` is the incoming Web API `Request` (body already consumed by the router), `rawBody` holds the exact body bytes, and `path` is the matched route key.
 
-Hook signatures (exported from `@zap-studio/webhooks`):
+Hook signatures (exported from `webhooks`):
 
 - `BeforeHook` — `(ctx: WebhookContext) => Promise<void> | void`
 - `AfterHook` — `(ctx: WebhookContext, response: Response) => Promise<void> | void`

--- a/apps/docs/content/webhooks/logging.mdx
+++ b/apps/docs/content/webhooks/logging.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/webhooks"
 ---
 
-`createWebhookRouter(...)` (and `new WebhookRouter(...)`) accept an optional `logger?: Logger` option from [`@zap-studio/logger`](/logger). Pass one to observe router internals; omit it and nothing is logged — zero overhead.
+`createWebhookRouter(...)` (and `new WebhookRouter(...)`) accept an optional `logger?: Logger` option from [`logger`](/logger). Pass one to observe router internals; omit it and nothing is logged — zero overhead.
 
 ```ts
 import { ConsoleLogger } from "@zap-studio/logger";
@@ -45,4 +45,4 @@ const logger: Logger = {
 const router = createWebhookRouter({ logger });
 ```
 
-See [`@zap-studio/logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.
+See [`logger`](/logger) for the full `Logger` interface and `ConsoleLogger` options.

--- a/apps/docs/content/webhooks/meta.ts
+++ b/apps/docs/content/webhooks/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/webhooks",
+  title: "webhooks",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/webhooks/opentelemetry.mdx
+++ b/apps/docs/content/webhooks/opentelemetry.mdx
@@ -58,4 +58,4 @@ Implicit context propagation — auto-linking the "active span" across `await` b
 
 ## Log Correlation
 
-Pair this with [`@zap-studio/logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so a delivery's spans and logs line up in whatever backend you send them to.
+Pair this with [`logger`](/logger/opentelemetry): once a span is active, `ConsoleLogger` automatically stamps `trace_id`/`span_id` onto every log line, so a delivery's spans and logs line up in whatever backend you send them to.

--- a/apps/docs/content/webhooks/standard-schema.mdx
+++ b/apps/docs/content/webhooks/standard-schema.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/webhooks"
 ---
 
-`@zap-studio/webhooks` validates route payloads through [Standard Schema](https://github.com/standard-schema/standard-schema), so it works with any compatible validation library — bring Zod, Valibot, ArkType, or any other Standard Schema implementation.
+`webhooks` validates route payloads through [Standard Schema](https://github.com/standard-schema/standard-schema), so it works with any compatible validation library — bring Zod, Valibot, ArkType, or any other Standard Schema implementation.
 
 ```ts
 import { createWebhookRouter } from "@zap-studio/webhooks";

--- a/apps/docs/content/webhooks/verification.mdx
+++ b/apps/docs/content/webhooks/verification.mdx
@@ -15,7 +15,7 @@ Always verify signatures against the **raw request body** (`ctx.rawBody`), exact
 
 ## Verify HMAC Signatures
 
-Use `createHmacVerifier` from `@zap-studio/webhooks` for providers that sign requests with a shared-secret HMAC (GitHub, and many others). It uses the Web Crypto API rather than Node `crypto`, so it works in any runtime that provides `globalThis.crypto.subtle`.
+Use `createHmacVerifier` from `webhooks` for providers that sign requests with a shared-secret HMAC (GitHub, and many others). It uses the Web Crypto API rather than Node `crypto`, so it works in any runtime that provides `globalThis.crypto.subtle`.
 
 ```ts
 import { createHmacVerifier, createWebhookRouter } from "@zap-studio/webhooks";
@@ -60,7 +60,7 @@ const verify = createHmacVerifier({
 
 ## Handle Verification Failures
 
-Import `VerificationError` from `@zap-studio/webhooks` to distinguish verification failures from other errors — for example, in an `onError` hook that maps them to a `401` instead of the default `500`.
+Import `VerificationError` from `webhooks` to distinguish verification failures from other errors — for example, in an `onError` hook that maps them to a `401` instead of the default `500`.
 
 ```ts
 import { createHmacVerifier, createWebhookRouter, VerificationError } from "@zap-studio/webhooks";
@@ -115,7 +115,7 @@ Write a custom verifier when a provider:
 - requires SDK-specific verification logic
 - includes timestamp or replay-protection checks
 
-If your custom verifier compares signatures itself, use `constantTimeEquals` from `@zap-studio/webhooks` instead of `===`. It compares byte arrays (`Uint8Array`), not strings — encode strings first.
+If your custom verifier compares signatures itself, use `constantTimeEquals` from `webhooks` instead of `===`. It compares byte arrays (`Uint8Array`), not strings — encode strings first.
 
 ```ts
 import { constantTimeEquals } from "@zap-studio/webhooks";

--- a/apps/docs/content/webmcp/errors.mdx
+++ b/apps/docs/content/webmcp/errors.mdx
@@ -5,7 +5,7 @@ type: package
 package: "@zap-studio/webmcp"
 ---
 
-WebMCP ships experimentally in Chrome/Edge only, as of this package's release. `@zap-studio/webmcp` gives you two ways to handle browsers without support: check ahead of time, or catch the rejection.
+WebMCP ships experimentally in Chrome/Edge only, as of this package's release. `webmcp` gives you two ways to handle browsers without support: check ahead of time, or catch the rejection.
 
 ## `hasWebMCPSupport`
 
@@ -41,7 +41,7 @@ This only happens in an actual browser without support — `registerTool` never 
 
 ## Falling Back to a Polyfill
 
-`@zap-studio/webmcp` has no required dependency on any polyfill — it only wraps whatever `document.modelContext` your app's environment provides. If you want WebMCP to work in browsers beyond Chrome/Edge, install a community polyfill such as [`@mcp-b/webmcp-polyfill`](https://www.npmjs.com/package/@mcp-b/webmcp-polyfill) yourself, before this package's code runs — `hasWebMCPSupport()` and `registerTool` pick it up the same way they pick up a native implementation, with no extra configuration.
+`webmcp` has no required dependency on any polyfill — it only wraps whatever `document.modelContext` your app's environment provides. If you want WebMCP to work in browsers beyond Chrome/Edge, install a community polyfill such as [`@mcp-b/webmcp-polyfill`](https://www.npmjs.com/package/@mcp-b/webmcp-polyfill) yourself, before this package's code runs — `hasWebMCPSupport()` and `registerTool` pick it up the same way they pick up a native implementation, with no extra configuration.
 
 ## `defineTool` Validation Errors
 
@@ -54,7 +54,7 @@ defineTool({ name: "invalid name!", description: "desc", execute: async () => "o
 
 ## Accessing `document.modelContext` Directly
 
-`@zap-studio/webmcp` never merges `modelContext` into the global `Document` type — a `declare global` augmentation like that is unsupported by JSR's public API analysis, and would leak into every consumer's own `Document` type whether they use WebMCP or not. `registerTool` and `hasWebMCPSupport` already handle this internally, so you only need to do anything extra if you want to call `document.modelContext` yourself — for example `getTools()` or `executeTool()`, for introspection outside of `registerTool`. Cast through the exported `WebMCPDocument` type instead of assuming the property exists:
+`webmcp` never merges `modelContext` into the global `Document` type — a `declare global` augmentation like that is unsupported by JSR's public API analysis, and would leak into every consumer's own `Document` type whether they use WebMCP or not. `registerTool` and `hasWebMCPSupport` already handle this internally, so you only need to do anything extra if you want to call `document.modelContext` yourself — for example `getTools()` or `executeTool()`, for introspection outside of `registerTool`. Cast through the exported `WebMCPDocument` type instead of assuming the property exists:
 
 ```ts
 import type { WebMCPDocument } from "@zap-studio/webmcp";

--- a/apps/docs/content/webmcp/index.mdx
+++ b/apps/docs/content/webmcp/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@zap-studio/webmcp"
+title: webmcp
 description: A framework-agnostic, SSR-safe wrapper around the native WebMCP document.modelContext API, with a batch tool registry for exposing JavaScript tools to AI agents.
 sidebar:
   label: Overview
@@ -7,7 +7,7 @@ type: package
 package: "@zap-studio/webmcp"
 ---
 
-`@zap-studio/webmcp` is a framework-agnostic, SSR-safe wrapper around the native WebMCP `document.modelContext` API, with a batch tool registry for exposing JavaScript tools to AI agents. It works with any framework, or no framework at all.
+`webmcp` is a framework-agnostic, SSR-safe wrapper around the native WebMCP `document.modelContext` API, with a batch tool registry for exposing JavaScript tools to AI agents. It works with any framework, or no framework at all.
 
 ## Motivation
 
@@ -15,7 +15,7 @@ package: "@zap-studio/webmcp"
 
 Calling `document.modelContext` directly has three rough edges for a real app. First, it crashes during server rendering — Next.js and TanStack Start both render on the server first, where there is no `document` at all. Second, unregistration is signal-based (abort a `signal` you passed at registration), which is easy to get wrong by hand for every tool a route exposes. Third, there is no batch primitive: a route with five tools means five separate `registerTool` calls and five separate cleanup paths to track.
 
-`@zap-studio/webmcp` fixes all three: every function no-ops safely with no `document`, `registerTool` hands back a single idempotent unregister function per tool, and `createToolRegistry` groups a route's tools so they mount and unmount together. The public API stays small: `defineTool`, `registerTool`, `createToolRegistry`, and nothing else.
+`webmcp` fixes all three: every function no-ops safely with no `document`, `registerTool` hands back a single idempotent unregister function per tool, and `createToolRegistry` groups a route's tools so they mount and unmount together. The public API stays small: `defineTool`, `registerTool`, `createToolRegistry`, and nothing else.
 
 ## Features
 
@@ -52,7 +52,7 @@ unregister();
 - [Getting Started](/webmcp/getting-started) — install and register your first tool step by step
 - [Tool Registry](/webmcp/registry) — batch-register a route's tools together
 - [Errors](/webmcp/errors) — `WebMCPNotSupportedError` and `hasWebMCPSupport()`
-- [React](/webmcp/react) — the `useWebMCPTool` hook from `@zap-studio/webmcp-react`
+- [React](/webmcp/react) — the `useWebMCPTool` hook from `webmcp-react`
 
 ## Runtime Support
 

--- a/apps/docs/content/webmcp/meta.ts
+++ b/apps/docs/content/webmcp/meta.ts
@@ -1,7 +1,7 @@
 import { defineMeta } from "blume";
 
 export default defineMeta({
-  title: "@zap-studio/webmcp",
+  title: "webmcp",
   display: "page",
   pages: ["getting-started", "registry", "errors", "react"],
 });


### PR DESCRIPTION
- Name pages, sidebar groups and prose after the package alone: `cache`, `fetch`, `retry`.
- Keep the `@zap-studio` scope where it names the published package: imports, install commands, subpath specifiers, npm and JSR links, peer-dependency sentences, and the `package` frontmatter that drives the search and MCP facet.
- Remove the CI and license badges, the install snippet and the "Start with fetch" link from the landing page.
- Drop the description from the header package selector, so it shows the name and version only.

Side effect: the 14 `BLUME_NAV_INDEX_TITLE_MISMATCH` warnings are gone, since each package page title now matches its folder title.
