### PR TITLE
docs: add site-wide guides and rework the getting started page

### DIFF
--- a/apps/docs/content/cache/meta.ts
+++ b/apps/docs/content/cache/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "cache",
+  icon: "database",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/composition.mdx
+++ b/apps/docs/content/composition.mdx
@@ -1,0 +1,165 @@
+---
+title: Composition
+description: Working recipes that put several Zap Studio packages on one request — retries around a validated call, a cached read, a verified webhook behind a permission check.
+sidebar:
+  icon: blocks
+  order: 4
+---
+
+Each package works alone. They also stack, because none of them owns the call stack: a policy, a cache and a router are values you pass around. These are the combinations worth knowing.
+
+## Retry a Validated Call
+
+`fetch` validates the response, `retry` decides how often to try again. The retry policy wraps the call, so a schema failure and a network failure are both retried the same way.
+
+```ts
+import { api } from "@zap-studio/fetch";
+import { exponentialBackoff, runRetryPolicy } from "@zap-studio/retry";
+import { z } from "zod";
+
+const UserSchema = z.object({ id: z.number(), name: z.string() });
+
+const policy = exponentialBackoff({
+  maxAttempts: 3,
+  baseDelayMs: 100,
+  maxDelayMs: 2_000,
+});
+
+const user = await runRetryPolicy(policy, () =>
+  api.get("https://api.example.com/users/1", UserSchema),
+);
+```
+
+Retrying everything is rarely what you want: a `400` will fail the same way three times. A [custom policy](/retry/custom-policies) decides per attempt — its `next` returns `shouldRetry: false` for an error that will not fix itself, so only transient failures cost you the extra attempts.
+
+## Cache What You Just Fetched
+
+`cache` sits in front of the call. The typed result goes in, so what comes back out of the cache is typed too.
+
+```ts
+import { createCache } from "@zap-studio/cache";
+import { api } from "@zap-studio/fetch";
+import { z } from "zod";
+
+const UserSchema = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof UserSchema>;
+
+const users = createCache<string, User>(100, { ttl: 60_000 });
+
+const getUser = async (id: string): Promise<User> => {
+  const hit = users.get(id);
+  if (hit) {
+    return hit;
+  }
+
+  const user = await api.get(`https://api.example.com/users/${id}`, UserSchema);
+  users.set(id, user);
+  return user;
+};
+```
+
+TTL is lazy: an entry expires when it is next read, not on a timer, so this adds no background work.
+
+## Verify, Route, Then Authorize a Webhook
+
+`webhooks` verifies the signature and validates the payload before your handler runs. `permit` decides whether this caller may act on the resource. `logger` records both.
+
+```ts
+import { ConsoleLogger } from "@zap-studio/logger";
+import { allow, createPolicy, when } from "@zap-studio/permit";
+import { createWebhookRouter } from "@zap-studio/webhooks";
+import { z } from "zod";
+
+const logger = new ConsoleLogger({ minLevel: "info" });
+
+const policy = createPolicy<{ tenantId: string }>({
+  resources: { invoice: z.object({ id: z.string(), tenantId: z.string() }) },
+  actions: { invoice: ["read", "settle"] },
+  rules: {
+    invoice: {
+      read: allow(),
+      settle: when((context, _action, invoice) => context.tenantId === invoice.tenantId),
+    },
+  },
+});
+
+const router = createWebhookRouter({ prefix: "/webhooks", logger });
+
+router.register("/invoices/paid", {
+  schema: z.object({ id: z.string(), tenantId: z.string() }),
+  handler: async ({ payload }) => {
+    const allowed = await policy.can({ tenantId: payload.tenantId }, "invoice:settle", payload);
+
+    if (!allowed) {
+      logger.warn("rejected invoice", { id: payload.id });
+      return Response.json({ error: "forbidden" }, { status: 403 });
+    }
+
+    return Response.json(`settled ${payload.id}`);
+  },
+});
+
+export default { fetch: (request: Request) => router.handle(request) };
+```
+
+Three checks run before your logic: the signature, the payload shape, then the permission. Each one fails on its own terms — `401`, `400`, `403` — instead of one handler guessing what went wrong.
+
+## Validate the Environment, Then Build the Client
+
+`env` fails at startup when a variable is missing, so the client below never has to handle an undefined base URL.
+
+```ts
+import { createEnvironment } from "@zap-studio/env";
+import { createFetch } from "@zap-studio/fetch";
+import { ConsoleLogger } from "@zap-studio/logger";
+import { z } from "zod";
+
+export const env = createEnvironment({
+  server: {
+    API_URL: z.string().url(),
+    API_TOKEN: z.string().min(1),
+  },
+  runtimeEnvStrict: {
+    API_URL: process.env.API_URL,
+    API_TOKEN: process.env.API_TOKEN,
+  },
+});
+
+export const { api } = createFetch({
+  baseURL: env.API_URL,
+  headers: { Authorization: `Bearer ${env.API_TOKEN}` },
+  logger: new ConsoleLogger({ minLevel: "debug" }),
+});
+```
+
+A missing `API_URL` now crashes the process on boot with the variable named, instead of sending a request to `undefined/users/1` in production.
+
+## One Logger for All of Them
+
+`fetch`, `permit`, `retry` and `webhooks` each accept an optional `logger?: Logger`. Pass the same instance to all four and one request produces one ordered story: the outgoing call, the retry, the permission decision, the response.
+
+```ts
+import { ConsoleLogger, jsonFormat } from "@zap-studio/logger";
+
+export const logger = new ConsoleLogger({ minLevel: "info", format: jsonFormat });
+```
+
+`Logger` is an interface, not a class you must use — any object with the six level methods works, so this can forward into the logging setup you already run. See [Observability](/logger/opentelemetry) for the tracing side.
+
+## Errors as Values
+
+Every recipe above throws on failure. If you would rather branch on a result, `monads` gives the same flows a `Result` shape, and `validation` gives one `ValidationError` shape whatever schema library produced the issue.
+
+## Next
+
+<CardGroup>
+
+<Card href="/principles" icon="compass" title="Principles">
+  Why the packages compose instead of integrating.
+</Card>
+
+<Card href="/runtimes" icon="cpu" title="Runtimes">
+  What each package needs from its runtime.
+</Card>
+
+</CardGroup>

--- a/apps/docs/content/env/meta.ts
+++ b/apps/docs/content/env/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "env",
+  icon: "sliders-horizontal",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/fetch/meta.ts
+++ b/apps/docs/content/fetch/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "fetch",
+  icon: "arrow-left-right",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -1,11 +1,53 @@
 ---
 title: Zap Studio
-description: "Type-safe, framework-agnostic TypeScript packages for HTTP calls, retries, auth, validation, logging, and webhooks — what Zap Studio is and how it compares."
+description: "Type-safe, framework-agnostic TypeScript packages for HTTP calls, retries, auth, validation, logging, and webhooks — install one and make your first typed call."
 sidebar:
   label: Getting Started
 ---
 
-## Quick Look
+Zap Studio is a set of small TypeScript packages for the code every app needs: HTTP calls, retries, permission checks, validation, logs, webhooks. Pick the one you need, install it, use it. No new runtime, no framework.
+
+This page takes about five minutes. At the end you will have a typed HTTP call that retries on failure.
+
+## Before You Start
+
+You need Node.js 18, Bun 1.0, Deno 1.42, a current Cloudflare Workers release, or an evergreen browser. [Runtimes](/runtimes) has the full matrix, including the four packages that ask for more.
+
+TypeScript 5 or later is recommended — the packages work in plain JavaScript, but the types are the point.
+
+## Install Your First Package
+
+Start with [`fetch`](/fetch). It makes an HTTP call and validates the response against a schema.
+
+<CodeGroup>
+
+```bash npm
+npm install @zap-studio/fetch zod
+```
+
+```bash yarn
+yarn add @zap-studio/fetch zod
+```
+
+```bash pnpm
+pnpm add @zap-studio/fetch zod
+```
+
+```bash bun
+bun add @zap-studio/fetch zod
+```
+
+```bash deno
+deno add jsr:@zap-studio/fetch npm:zod
+```
+
+</CodeGroup>
+
+You also need a schema library that implements [Standard Schema](https://standardschema.dev) — Zod, Valibot, or ArkType. This page uses Zod.
+
+## Make a Typed Call
+
+A **schema** describes the shape you expect back. You pass it to `api.get`, which validates the response at runtime and infers the type from it.
 
 ```ts
 import { api } from "@zap-studio/fetch";
@@ -18,10 +60,76 @@ const UserSchema = z.object({
 });
 
 // `user` is typed from UserSchema — no manual annotations, no `as` casts
-const user = await api.get("https://api.example.com/users/1", UserSchema);
+const user = await api.get("https://jsonplaceholder.typicode.com/users/1", UserSchema);
+
+console.log(user.name);
 ```
 
-## Packages
+Run it. You get:
+
+```txt
+Leanne Graham
+```
+
+Change `name: z.string()` to `name: z.number()` and run it again. The call throws a `ValidationError` instead of handing you bad data. That is the whole idea: the response is checked before your code touches it.
+
+## Add a Second Package
+
+Packages compose. Wrap the same call in a retry policy so a flaky network does not break it.
+
+<CodeGroup>
+
+```bash npm
+npm install @zap-studio/retry
+```
+
+```bash yarn
+yarn add @zap-studio/retry
+```
+
+```bash pnpm
+pnpm add @zap-studio/retry
+```
+
+```bash bun
+bun add @zap-studio/retry
+```
+
+```bash deno
+deno add jsr:@zap-studio/retry
+```
+
+</CodeGroup>
+
+A **retry policy** decides how many attempts to make and how long to wait between them. `exponentialBackoff` doubles the delay after each failure, up to a cap.
+
+```ts
+import { api } from "@zap-studio/fetch";
+import { exponentialBackoff, runRetryPolicy } from "@zap-studio/retry";
+import { z } from "zod";
+
+const UserSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  email: z.email(),
+});
+
+const policy = exponentialBackoff({
+  maxAttempts: 3, // total attempts, including the first
+  baseDelayMs: 100, // first retry waits 100 ms
+  maxDelayMs: 2_000, // later retries never wait longer than 2 s
+});
+
+const user = await runRetryPolicy(policy, () =>
+  api.get("https://jsonplaceholder.typicode.com/users/1", UserSchema),
+);
+
+console.log(user.name);
+```
+
+Same output, three attempts instead of one. Point the URL at `https://jsonplaceholder.typicode.com/nope` and watch it try three times before it throws.
+
+## Pick Your Package
 
 | Package                       | What you get                                                      |
 | ----------------------------- | ----------------------------------------------------------------- |
@@ -42,29 +150,26 @@ const user = await api.get("https://api.example.com/users/1", UserSchema);
 
 Install only the packages you need — each one works standalone.
 
-## Why Zap Studio
+## Where to Go Next
 
-Most teams solve these problems by hand, per project — and the hard parts get skipped:
+<CardGroup>
 
-- **Fragile by default.** Hand-rolled retries and webhook checks quietly skip the parts that matter.
-- **Scattered, not audited.** Permission checks end up copy-pasted across the codebase instead of living in one place.
-- **Node-only, until it isn't.** Homegrown wrappers break the moment your code runs on an edge runtime or in the browser.
+<Card href="/composition" icon="blocks" title="Composition">
+  Stack several packages on one request: retries, caching, verified webhooks.
+</Card>
 
-## Every Package Follows the Same Rules
+<Card href="/installation" icon="download" title="Installation">
+  npm and JSR, peer dependencies, subpath imports.
+</Card>
 
-- **Type safety.** Types come from your schema via [Standard Schema](https://standardschema.dev), not hand-written annotations.
-- **Framework-agnostic.** Built on standard runtime APIs — `fetch`, `Request`/`Response`, `AbortSignal`.
-- **Composable.** Combine packages as needed — wrap a `fetch` call in a `retry` policy, validate a webhook with `validation`.
-- **Tree-shakeable.** Standalone functions, no shared state — unused exports drop out of your bundle.
+<Card href="/runtimes" icon="cpu" title="Runtimes">
+  Node, Bun, Deno, Workers and browser support, per package.
+</Card>
 
-## Compared to Effect
+<Card href="/principles" icon="compass" title="Principles">
+  The four rules every package follows — and where Zap Studio stops.
+</Card>
 
-If you know [Effect](https://effect.website): yes, there's overlap — typed errors, retries, schema validation. Effect is a full ecosystem built around its own runtime, and that investment pays off once you need that level of control.
+</CardGroup>
 
-Zap Studio stays in plain TypeScript — no new runtime, no new mental model, small packages you adopt one at a time. Reach for it when you don't need everything Effect brings.
-
-## Not For You If
-
-- You want one framework that owns your whole effect/error model — Effect is built for that.
-- You need every package to come from a single all-in-one SDK.
-- What you have today isn't costing you bugs.
+Or go deeper on what you just built: [`fetch` Getting Started](/fetch/getting-started) for error handling, POST/PUT/DELETE and configured clients, [`retry` Getting Started](/retry/getting-started) for jitter, cancellation and result objects instead of throws.

--- a/apps/docs/content/installation.mdx
+++ b/apps/docs/content/installation.mdx
@@ -1,0 +1,109 @@
+---
+title: Installation
+description: Install any Zap Studio package from npm or JSR, pick the peer dependencies you need, and import only the code you use.
+sidebar:
+  icon: download
+  order: 1
+---
+
+Every package installs on its own. There is no meta-package, no shared runtime, and no setup step — install one, import it, use it.
+
+## Install a Package
+
+Replace `fetch` with the package you want.
+
+<CodeGroup>
+
+```bash npm
+npm install @zap-studio/fetch
+```
+
+```bash yarn
+yarn add @zap-studio/fetch
+```
+
+```bash pnpm
+pnpm add @zap-studio/fetch
+```
+
+```bash bun
+bun add @zap-studio/fetch
+```
+
+```bash deno
+deno add jsr:@zap-studio/fetch
+```
+
+</CodeGroup>
+
+npm, yarn, pnpm and bun install from npm. Deno installs from [JSR](https://jsr.io/@zap-studio), where every package is published in parallel under the same name and version.
+
+The two tooling packages are dev dependencies, since they only run at lint or format time:
+
+<CodeGroup>
+
+```bash npm
+npm install --save-dev @zap-studio/oxlint oxlint
+```
+
+```bash pnpm
+pnpm add -D @zap-studio/oxlint oxlint
+```
+
+</CodeGroup>
+
+## Peer Dependencies
+
+A peer dependency is a package you install yourself, so you control its version. Most packages have none.
+
+| Package                                            | Required peer                                  | Optional peer        |
+| -------------------------------------------------- | ---------------------------------------------- | -------------------- |
+| `env`, `logger`                                    | `@opentelemetry/api`                           | —                    |
+| `fetch`, `permit`, `retry`, `webhooks`             | `@opentelemetry/api`                           | `@zap-studio/logger` |
+| `oxfmt`                                            | `oxfmt`                                        | —                    |
+| `oxlint`                                           | `oxlint`, `@oxlint/plugins`, `oxlint-tsgolint` | —                    |
+| `react-hooks`                                      | `react`                                        | —                    |
+| `cache`, `monads`, `store`, `validation`, `webmcp` | —                                              | —                    |
+
+`@opentelemetry/api` is small and side-effect free. It stays a no-op until you register a real SDK, so installing it costs nothing until you want traces — see each package's OpenTelemetry page, such as [`fetch`](/fetch/opentelemetry).
+
+A schema library is not a dependency of anything, but `env`, `fetch`, `permit`, `validation` and `webhooks` validate through [Standard Schema](https://standardschema.dev), so you install the one you like: Zod, Valibot or ArkType.
+
+```bash
+npm install zod
+```
+
+## Import What You Use
+
+Every package exports from its root, and most also expose one subpath per feature. Both forms give you the same function; the subpath is there when you want the smallest possible import graph.
+
+```ts
+import { createCache } from "@zap-studio/cache";
+import { lru } from "@zap-studio/cache/lru";
+```
+
+`react-hooks` takes this the furthest: each of its 100+ hooks is its own module, so importing one never pulls in the rest.
+
+```ts
+import { useIsMobile } from "@zap-studio/react-hooks/sensors/use-is-mobile";
+```
+
+## TypeScript
+
+TypeScript 5 or later is recommended. The packages run in plain JavaScript, but the types are the point — response shapes, permission checks and environment variables are all inferred from the schema you pass in.
+
+Every package ships standard ESM with its own type declarations. There is no CommonJS build, so a `require()` call will not resolve them.
+
+## Next
+
+<CardGroup>
+
+<Card href="/runtimes" icon="cpu" title="Runtimes">
+  Minimum Node, Bun, Deno, Workers and browser versions, per package.
+</Card>
+
+<Card href="/" icon="rocket" title="Getting Started">
+  Make your first typed call in five minutes.
+</Card>
+
+</CardGroup>

--- a/apps/docs/content/logger/meta.ts
+++ b/apps/docs/content/logger/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "logger",
+  icon: "scroll-text",
   display: "page",
   pages: ["getting-started", "formats", "runtime-compatibility", "opentelemetry"],
 });

--- a/apps/docs/content/monads/meta.ts
+++ b/apps/docs/content/monads/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "monads",
+  icon: "git-branch",
   display: "page",
   pages: ["getting-started", "result", "result-async", "option", "pipe"],
 });

--- a/apps/docs/content/oxfmt/meta.ts
+++ b/apps/docs/content/oxfmt/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "oxfmt",
+  icon: "align-left",
   display: "page",
   pages: ["getting-started", "presets"],
 });

--- a/apps/docs/content/oxlint/meta.ts
+++ b/apps/docs/content/oxlint/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "oxlint",
+  icon: "check-check",
   display: "page",
   pages: ["getting-started", "presets", "plugins", "anti-slop"],
 });

--- a/apps/docs/content/permit/meta.ts
+++ b/apps/docs/content/permit/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "permit",
+  icon: "lock",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/principles.mdx
+++ b/apps/docs/content/principles.mdx
@@ -1,0 +1,59 @@
+---
+title: Principles
+description: The four rules every Zap Studio package follows, the problems they answer, and where Zap Studio stops.
+sidebar:
+  icon: compass
+  order: 3
+---
+
+Fourteen packages, one set of rules. This page says what those rules are, so you can predict how a package you have not read yet will behave.
+
+## The Problem
+
+Most teams solve these problems by hand, per project — and the hard parts get skipped:
+
+- **Fragile by default.** Hand-rolled retries and webhook checks quietly skip the parts that matter: jitter, cancellation, constant-time signature comparison.
+- **Scattered, not audited.** Permission checks end up copy-pasted across the codebase instead of living in one place you can read in one sitting.
+- **Node-only, until it isn't.** Homegrown wrappers break the moment your code runs on an edge runtime or in the browser.
+
+## What Every Package Guarantees
+
+- **Type safety.** Types come from your schema through [Standard Schema](https://standardschema.dev), not from hand-written annotations. No `as` casts to make a response fit.
+- **Framework-agnostic.** Built on standard runtime APIs — `fetch`, `Request`/`Response`, `AbortSignal`, `crypto.subtle`. No framework adapter, no plugin system, no global setup.
+- **Composable.** Each package does one thing and accepts the others as plain values: wrap a `fetch` call in a `retry` policy, validate a webhook payload with `validation`, pass a `logger` to any of them.
+- **Tree-shakeable.** Standalone functions with no shared state, one subpath per feature. What you do not import does not ship.
+
+## What That Rules Out
+
+These follow from the four rules above, and they are choices, not omissions:
+
+- **No runtime of its own.** No effect system, no scheduler, no dependency injection container. Functions in, values out.
+- **No hidden state.** Nothing registers a global, patches a prototype, or reads an implicit context. A cache, a policy or a router is a value you created and can throw away.
+- **No required logging or tracing.** Both are optional parameters. Pass nothing and there is no dependency and no cost.
+- **No CommonJS.** Standard ESM only, so the tree-shaking guarantee holds.
+
+## Compared to Effect
+
+If you know [Effect](https://effect.website): yes, there is overlap — typed errors, retries, schema validation. Effect is a full ecosystem built around its own runtime, and that investment pays off once you need that level of control.
+
+Zap Studio stays in plain TypeScript — no new runtime, no new mental model, small packages you adopt one at a time. Reach for it when you don't need everything Effect brings.
+
+## Not For You If
+
+- You want one framework that owns your whole effect/error model — Effect is built for that.
+- You need every package to come from a single all-in-one SDK.
+- What you have today isn't costing you bugs.
+
+## Next
+
+<CardGroup>
+
+<Card href="/composition" icon="blocks" title="Composition">
+  The composability rule, in working code.
+</Card>
+
+<Card href="/" icon="rocket" title="Getting Started">
+  Install one package and make a typed call.
+</Card>
+
+</CardGroup>

--- a/apps/docs/content/react-hooks/meta.ts
+++ b/apps/docs/content/react-hooks/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "react-hooks",
+  icon: "atom",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/retry/meta.ts
+++ b/apps/docs/content/retry/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "retry",
+  icon: "refresh-cw",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/runtimes.mdx
+++ b/apps/docs/content/runtimes.mdx
@@ -1,0 +1,61 @@
+---
+title: Runtimes
+description: The runtimes every Zap Studio package supports, the shared baseline, and the four packages that ask for more.
+sidebar:
+  icon: cpu
+  order: 2
+---
+
+Every package targets the same baseline. Four packages need more than it, because of the browser API they build on.
+
+## The Baseline
+
+| Runtime            | Minimum version                         |
+| ------------------ | --------------------------------------- |
+| Node.js            | 18.0.0                                  |
+| Bun                | 1.0.0                                   |
+| Deno               | 1.42                                    |
+| Cloudflare Workers | Any current release                     |
+| Browsers           | Chrome/Edge 98, Firefox 97, Safari 15.4 |
+
+Nothing here uses a runtime-specific API. The packages are built on `fetch`, `Request`/`Response`, `AbortSignal` and `crypto.subtle` — web standards that every runtime above implements.
+
+Deno 1.42 is the first release that installs packages from JSR, which is how Deno gets them: `deno add jsr:@zap-studio/fetch`.
+
+## Where a Package Asks for More
+
+| Package    | Extra requirement                                                                                                                                                                                                                  |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fetch`    | A global `fetch`. Native from Node.js 18.                                                                                                                                                                                          |
+| `webhooks` | The verification helper needs `globalThis.crypto.subtle`: global from Node.js 19, or Node.js 18 with `--experimental-global-webcrypto`. Browsers need a secure context (HTTPS). The router itself only needs `Request`/`Response`. |
+| `retry`    | Cancellation reads `AbortSignal.reason`, which sets the browser minimums in the table above.                                                                                                                                       |
+| `webmcp`   | A browser with the native WebMCP API — today Chrome/Edge behind a flag. Everywhere else it is a safe no-op, so server rendering never breaks.                                                                                      |
+
+`react-hooks` runs wherever React runs. Individual hooks wrap browser APIs of varying maturity, and each one fails closed — a hook reports `supported: false` instead of throwing when its API is missing. The `useExperimental*` prefix marks those.
+
+`oxfmt` and `oxlint` are configuration presets. They run in your linter or formatter, not in your application, so the table above does not apply to them.
+
+## Server Rendering
+
+Nothing touches `window`, `document` or `navigator` at module scope, so importing any package on the server is safe. The two browser-facing packages go further:
+
+- `react-hooks` reads browser APIs inside effects or behind guards, so server renders never throw and hydration never mismatches.
+- `webmcp` registers tools only when a real `document.modelContext` exists.
+
+## Modules
+
+Every package ships standard ESM only, with no CommonJS build. Node.js resolves it through the `exports` field, so a `require()` call fails on purpose rather than loading a stale bundle.
+
+## Next
+
+<CardGroup>
+
+<Card href="/installation" icon="download" title="Installation">
+  Install from npm or JSR, and the peer dependencies each package expects.
+</Card>
+
+<Card href="/composition" icon="blocks" title="Composition">
+  Put several packages together on one request.
+</Card>
+
+</CardGroup>

--- a/apps/docs/content/store/meta.ts
+++ b/apps/docs/content/store/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "store",
+  icon: "box",
   display: "page",
   pages: ["getting-started", "set", "derive", "persist", "react"],
 });

--- a/apps/docs/content/validation/meta.ts
+++ b/apps/docs/content/validation/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "validation",
+  icon: "shield-check",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/webhooks/meta.ts
+++ b/apps/docs/content/webhooks/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "webhooks",
+  icon: "webhook",
   display: "page",
   pages: [
     "getting-started",

--- a/apps/docs/content/webmcp/meta.ts
+++ b/apps/docs/content/webmcp/meta.ts
@@ -2,6 +2,7 @@ import { defineMeta } from "blume";
 
 export default defineMeta({
   title: "webmcp",
+  icon: "bot",
   display: "page",
   pages: ["getting-started", "registry", "errors", "react"],
 });


### PR DESCRIPTION
Four site-wide guides, listed above the package groups in the sidebar, each with its own icon.

- **Installation** (`download`) — install commands for npm, yarn, pnpm, bun and Deno/JSR, the peer dependency table read from the package manifests, subpath imports, TypeScript and the ESM-only note.
- **Runtimes** (`cpu`) — the shared baseline matrix, plus the four packages that need more than it: `fetch` (global `fetch`), `webhooks` (`crypto.subtle`, Node 19 or the Node 18 flag, secure context in browsers), `retry` (`AbortSignal.reason`), `webmcp` (native WebMCP, no-op elsewhere). Replaces the paragraph 12 package pages repeat.
- **Principles** (`compass`) — the problem, the four guarantees, what they rule out, the Effect comparison and the limits. Moved off the landing page.
- **Composition** (`blocks`) — five working recipes: retry around a validated call, cache in front of a fetch, verified webhook behind a permission check, environment validated before the client is built, one logger across four packages. Nothing covered this before.

Getting started page reworked:

- Runtime list replaced by one line linking to Runtimes.
- The trailing philosophy sections moved to Principles, replaced by a card group linking the four guides.
- The five-minute tutorial, the package table and the deeper `fetch`/`retry` links stay.

Also: each of the 14 package groups gets a sidebar icon, so the site-wide pages and the package sections read as two different things at a glance.

Every code sample was checked against the package sources: `createCache(capacity, { ttl })`, `runRetryPolicy` with `exponentialBackoff`, `createPolicy`/`can`, `createWebhookRouter`/`register`/`handle`, `createEnvironment` with `runtimeEnvStrict`, `createFetch` with `logger`, and `ConsoleLogger` with `format`.
