### PR TITLE
chore: add bump file for peer dependency range widening

### DIFF
--- a/.bumpy/peer-dep-ranges.md
+++ b/.bumpy/peer-dep-ranges.md
@@ -1,0 +1,10 @@
+---
+"@zap-studio/fetch": patch
+"@zap-studio/permit": patch
+"@zap-studio/retry": patch
+"@zap-studio/webhooks": patch
+"@zap-studio/store-react": patch
+"@zap-studio/webmcp-react": patch
+---
+
+Widen internal peer dependency ranges from an exact pin to a caret range, so consumers no longer resolve a duplicate copy of the peer on version skew.


### PR DESCRIPTION
Records a patch release for the six packages whose internal peer
dependency ranges changed from `workspace:*` to `workspace:^`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
