### PR TITLE
ci: disable lefthook in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  LEFTHOOK: 0
+
 jobs:
   plan:
     name: Plan


### PR DESCRIPTION
`bumpy ci release` commits the version bump, which fired the lefthook
pre-commit hook on the runner. The format job loads oxfmt.config.ts,
which imports @zap-studio/oxfmt/dist/base.js — not built in that job —
so the commit failed and no version PR was opened.

Git hooks exist for local development; CI already runs format, lint and
typecheck in the Check job.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
