### PR TITLE
ci: exclude generated changelogs from format checks

### DIFF
--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,4 +1,7 @@
 import zapStudio from "@zap-studio/oxfmt/base";
 import { defineConfig } from "oxfmt";
 
-export default defineConfig(zapStudio);
+export default defineConfig({
+  ...zapStudio,
+  ignorePatterns: ["**/CHANGELOG.md"],
+});


### PR DESCRIPTION
bumpy generates `CHANGELOG.md` entries in its own style, which oxfmt then rewrites (emphasis markers, blank lines, spacing). That made the version PR fail `format:check` on all six changed packages.

Generated files should not be format-gated, so this excludes them via oxfmt's native `ignorePatterns`.

Scoped to the root config rather than the shared `@zap-studio/oxfmt` base, since the base is published and the rule is this repo's concern.

Verified against the failing files on `bumpy/version-packages`: `All matched files use the correct format.` (894 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)