### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/validation-dep-range.md
+++ b/.bumpy/validation-dep-range.md
@@ -1,8 +1,0 @@
----
-"@zap-studio/env": patch
-"@zap-studio/fetch": patch
-"@zap-studio/permit": patch
-"@zap-studio/webhooks": patch
----
-
-Widen the internal `@zap-studio/validation` dependency range from an exact pin to a caret range, so consumers no longer resolve a duplicate copy on version skew.

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## 1.0.2
+<sub>2026-09-13</sub>
+
+- [#617](https://github.com/zap-studio/monorepo/pull/617)  *(patch)* Thanks [@alexandretrotel](https://github.com/alexandretrotel)!
+  Widen the internal `@zap-studio/validation` dependency range from an exact pin to a caret range, so consumers no longer resolve a duplicate copy on version skew.
+
 ## [1.0.1]
 
 ### Fixed

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zap-studio/env",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": false,
   "description": "A runtime and framework-agnostic, Standard Schema-based environment variable validator.",
   "keywords": [

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+
+## 2.1.4
+<sub>2026-09-13</sub>
+
+- [#617](https://github.com/zap-studio/monorepo/pull/617)  *(patch)* Thanks [@alexandretrotel](https://github.com/alexandretrotel)!
+  Widen the internal `@zap-studio/validation` dependency range from an exact pin to a caret range, so consumers no longer resolve a duplicate copy on version skew.
+
 ## 2.1.3
 <sub>2026-09-13</sub>
 

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zap-studio/fetch",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": false,
   "description": "A type-safe, tree-shakeable fetch wrapper for HTTP requests with runtime schema validation.",
   "keywords": [

--- a/packages/permit/CHANGELOG.md
+++ b/packages/permit/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+
+## 2.0.3
+<sub>2026-09-13</sub>
+
+- [#617](https://github.com/zap-studio/monorepo/pull/617)  *(patch)* Thanks [@alexandretrotel](https://github.com/alexandretrotel)!
+  Widen the internal `@zap-studio/validation` dependency range from an exact pin to a caret range, so consumers no longer resolve a duplicate copy on version skew.
+
 ## 2.0.2
 <sub>2026-09-13</sub>
 

--- a/packages/permit/package.json
+++ b/packages/permit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zap-studio/permit",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": false,
   "description": "A type-safe, declarative, tree-shakeable authorization library for TypeScript with Standard Schema support.",
   "keywords": [

--- a/packages/webhooks/CHANGELOG.md
+++ b/packages/webhooks/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+
+## 2.1.2
+<sub>2026-09-13</sub>
+
+- [#617](https://github.com/zap-studio/monorepo/pull/617)  *(patch)* Thanks [@alexandretrotel](https://github.com/alexandretrotel)!
+  Widen the internal `@zap-studio/validation` dependency range from an exact pin to a caret range, so consumers no longer resolve a duplicate copy on version skew.
+
 ## 2.1.1
 <sub>2026-09-13</sub>
 

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zap-studio/webhooks",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": false,
   "description": "A lightweight, type-safe, tree-shakeable webhook router with Standard Schema validation, signature verification, and lifecycle hooks.",
   "keywords": [


### PR DESCRIPTION
Merging this PR will release the following packages.

### Patch releases

- `@zap-studio/env` 1.0.1 → **1.0.2**
- `@zap-studio/fetch` 2.1.3 → **2.1.4**
- `@zap-studio/permit` 2.0.2 → **2.0.3**
- `@zap-studio/webhooks` 2.1.1 → **2.1.2**

Widen the internal `@zap-studio/validation` dependency range from an exact pin to a caret range, so consumers no longer resolve a duplicate copy on version skew.

---
_bumpy pushed this branch correctly, but `gh pr create` hit repeated GitHub GraphQL server errors, so this PR was opened via the REST API instead._